### PR TITLE
ci: publish to NuGet.org via Trusted Publishing instead of an API key

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -41,6 +41,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # OIDC token for NuGet.org Trusted Publishing
 
     steps:
       - name: "Checkout"
@@ -112,6 +113,17 @@ jobs:
             --package-version ${{ github.event.inputs.package-version }} \
             --package-secret ${{ secrets.GITHUB_TOKEN }}
 
+      # Trusted Publishing: exchange a GitHub OIDC token for a short-lived NuGet.org key, so there is no
+      # long-lived NUGET_API_KEY to rotate or leak. The key lives one hour, hence immediately before the
+      # push rather than at the top of the job.
+      # Policy: owner LocalStack.NET, repo localstack-dotnet/localstack-dotnet-client, workflow publish-nuget.yml.
+      - name: "NuGet.org login (OIDC)"
+        id: nuget-login
+        if: ${{ github.event.inputs.package-source == 'nuget' }}
+        uses: NuGet/login@v1
+        with:
+          user: localstack-dotnet
+
       - name: "Publish to NuGet.org"
         if: ${{ github.event.inputs.package-source == 'nuget' }}
         run: |
@@ -119,7 +131,7 @@ jobs:
             --package-source nuget \
             --package-id ${{ github.event.inputs.package-id }} \
             --package-version ${{ github.event.inputs.package-version }} \
-            --package-secret ${{ secrets.NUGET_API_KEY }}
+            --package-secret ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
 
       - name: "Upload Package Artifacts"
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## 📝 Description

Replaces the long-lived `NUGET_API_KEY` with **Trusted Publishing** (GitHub OIDC → short-lived nuget.org key) for the NuGet.org publish path.

**Why now.** The v2.0.1 publish failed with:

```
Forbidden https://www.nuget.org/api/v2/package/ 233ms
error: 403 (The specified API key is invalid, has expired, or does not have
       permission to access the specified package.)
```

`NUGET_API_KEY` had aged out. The last successful publish was 2025-07-25 and nuget.org caps API keys at 365 days, so it expired almost to the day. nuget.org now also marks API keys **"Not recommended"** and routes key creation towards Trusted Publishing, so rotating was not the straightforward path anyway.

This is the **second** credential of that vintage to die silently in this repo — `GIST_SECRET` has been returning `401` for the badge pipeline since the same week, which is why the README test badges have served July 2025 numbers ever since. Trusted Publishing removes the whole class: nothing to rotate, store, or leak.

## 🔄 Type of Change

- [x] 🧹 Code cleanup/refactoring
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change

## What changed

- `id-token: write` added to the `publish-manual` job permissions.
- A `NuGet/login@v1` step runs **immediately before** the push — the temporary key is valid for one hour, so requesting it early would risk expiry.
- Its output replaces the secret in the existing `--package-secret` argument.

The Cake `nuget-push` task is **unchanged** — it already pushes to `https://api.nuget.org/v3/index.json`. The GitHub Packages path still uses `GITHUB_TOKEN` and is untouched.

## Required nuget.org policy

Already created and **active**:

| Field | Value |
|---|---|
| Package Owner | `LocalStack.NET` |
| Repository Owner | `localstack-dotnet` (#50793344) |
| Repository | `localstack-dotnet-client` (#187457001) |
| Workflow File | `publish-nuget.yml` |
| Environment | *(none)* |

Note the two distinct owners: the **package** owner on nuget.org is `LocalStack.NET`, while the **repository** owner is `localstack-dotnet`. Using the latter for both would produce a policy that does not cover these packages.

## 🧪 Verification

Proven end-to-end before merge, not after: **`LocalStack.Client.Extensions` 2.0.1 was published to nuget.org by this exact workflow**, run from this branch.

```
Pushing LocalStack.Client.Extensions.2.0.1.nupkg to 'https://www.nuget.org/api/v2/package'...
Your package was pushed.
Pushing LocalStack.Client.Extensions.2.0.1.snupkg to 'https://www.nuget.org/api/v2/symbolpackage'...
Your package was pushed.
```

Two things the docs left ambiguous, now settled by that run:

- **`user:` for an organization-owned policy** — neither the Microsoft docs nor the `NuGet/login` README says whether this is the individual account or the org. The individual account name (`localstack-dotnet`) is correct.
- **Branch scope** — the policy has no branch field, and the publish succeeded from this feature branch, so it binds to the workflow *filename* rather than a ref.

## 🔍 Notes

`NUGET_API_KEY` is left in repo secrets deliberately — it is expired and unused, but removing it is a separate cleanup once this has a few releases behind it.